### PR TITLE
modify the code about create zebra crossing

### DIFF
--- a/Algebras/TransportationMode/Partition.cpp
+++ b/Algebras/TransportationMode/Partition.cpp
@@ -3467,7 +3467,7 @@ If the four points can construct a zebra, returns true, otherwise return false
                   ComputeRegion(outer_ps1, result1);
 
 //              if(result1[0].GetCycleDirection() &&
-              if(result1.size() > 0 && result1[0].GetCycleDirection() &&
+              if(result1.size() > 0 && !result1[0].GetCycleDirection() &&
                  result1[0].Intersects(*last_zc) == false){
                   *crossregion = result1[0];
                   *pave1 = *pave;


### PR DESCRIPTION
I found a problem while running `createpave1.sec`. The call of operator `junregion` at `line76` supposed to create many regions at junctions of roads. But the result `pave_regions2` is an empty region. The modified code can fix it.