### PR TITLE
Update optimizer syntax

### DIFF
--- a/Optimizer/Subqueries/subqueries.pl
+++ b/Optimizer/Subqueries/subqueries.pl
@@ -3136,7 +3136,7 @@ Translate a list of values into kernel syntax for lists.
 */
 
 secondo_list_to_atom(CommaList, Result) :-
-  CommaList =.. [(,), X, Xs],
+  CommaList =.. [',', X, Xs],
   plan_to_atom(X, XAtom),
   secondo_list_to_atom((Xs), XsAtom),
   my_concat_atom([XAtom, ' ', XsAtom], '', Result),
@@ -3156,7 +3156,7 @@ subquery_plan_to_atom(Data, Result) :-
 % in expression with constant list
 subquery_plan_to_atom(X, Result) :-
   X =.. [in, Attr, ValueList],
-  ValueList =.. [(,) | _],
+  ValueList =.. [',' | _],
   constantType(Attr, Type),
   plan_to_atom(Attr, AttrAtom),
   secondo_list_to_atom(ValueList, VLAtom),

--- a/Optimizer/operators.pl
+++ b/Optimizer/operators.pl
@@ -525,7 +525,7 @@ opSignature(setoption, standard, [string,int],bool,[sidefx]).
 opSignature(abs, standard, [int],int,[]).
 opSignature(abs, standard, [real],real,[]).
 
-opSignature((,), standard, [T,T],[T,[set,T]],[]). % op provided by Poneleit
+opSignature(',', standard, [T,T],[T,[set,T]],[]). % op provided by Poneleit
 
 
 

--- a/Optimizer/statistics.pl
+++ b/Optimizer/statistics.pl
@@ -2815,11 +2815,11 @@ Auxiliary predicate
 
 (1) transforms a type expression ~Type~ using square brackets and commas as
 delimiters into an atom with the equivalent nested list representation using
-round parantheses.
+round parentheses.
 
 (2) transforms a type expression ~Type~ using round brackets and commas as
 delimiters into an atom with the equivalent nested list representation using
-round parantheses.
+round parentheses.
 
 */
 
@@ -2851,7 +2851,7 @@ nestedTypeExpr2valueTypeExprAtom_list([A|B],Result) :-
 
 valueTypeExpr2valueTypeExprAtom(Term,Result) :-
   term_to_atom(Term,TermAtom),
-  ( (compound(Term), functor(Term,(,),_))
+  ( (compound(Term), functor(Term,',', _))
     -> my_concat_atom(['(',TermAtom,')'],'',Result)
     ;  Result = TermAtom
   ),


### PR DESCRIPTION
Optimizer fix for the following syntax errors:

```
Processing 'MainMemory2Algebra' (164 operators)
Processing 'GeoidAlgebra' (3 operators)
Processing 'SymbolicTrajectoryBasicAlgebra' (39 operators)

SecondoPLTTYMode.cpp:1882 Calling PL_initialize with pl -g true --stack-limit=256M

ERROR: /tmp/secondo/Optimizer/Subqueries/[subqueries.pl:3139](http://subqueries.pl:3139/):17: Syntax error: Operand expected, unquoted comma or bar found
ERROR: /tmp/secondo/Optimizer/Subqueries/[subqueries.pl:3159](http://subqueries.pl:3159/):17: Syntax error: Operand expected, unquoted comma or bar found
ERROR: /tmp/secondo/Optimizer/[statistics.pl:2854](http://statistics.pl:2854/):34: Syntax error: Operand expected, unquoted comma or bar found
ERROR: /tmp/secondo/Optimizer/[operators.pl:528](http://operators.pl:528/):13: Syntax error: Operand expected, unquoted comma or bar found
Switched OFF option: 'allOff' - Turn off really ALL options.

Switched off all options.
```